### PR TITLE
Fix 64-bit upper half power 

### DIFF
--- a/nbt.js
+++ b/nbt.js
@@ -59,7 +59,7 @@
 			/* FIXME: this can overflow, JS has 53 bit precision */
 			var upper = this.int();
 			var lower = this.int();
-			return (upper << 32) + lower;
+			return (upper * 4294967296) + lower;
 		};
 
 		this[nbt.tagTypes.byteArray] = function() {


### PR DESCRIPTION
Bitwise operators unfortunately only operate on 32-bit integers, so x<<32 === x, and

```
        return (upper << 32) + lower;
```

is equivalent to upper + lower. For example this NBT file: https://github.com/deathcap/playerdat/blob/master/test.dat parses as:

```
"firstPlayed": 2016156000
```

This PR changes the calculation to:

```
        return (upper * 4294967296) + lower;
```

so it can use the full range of 53-bit floating point, giving the correct value:

```
"firstPlayed": 1367815755810
```

(cross checked with NBTExplorer and https://github.com/maxogden/minecraft-nbt/pull/2)

Precision loss can still occur (above 2^53 = 9007199254740992), so this doesn't fix GH-1 completely, but it takes care of some common cases.
