### PR TITLE
Use node-int64 for 64-bit long integers. Closes GH-1

### DIFF
--- a/nbt-spec.js
+++ b/nbt-spec.js
@@ -41,11 +41,17 @@ describe('nbt.Reader', function() {
 			0,0,0,0,0,0,0,255,
 			-127,0,0,0,0,0,0,0
 		]));
-		expect(reader.long()).toEqual(0);
-		expect(reader.long()).toEqual(255);
+		expect(+reader.long()).toEqual(0);
+		expect(+reader.long()).toEqual(255);
 
-		/* false pass - JS only has 53 bit precision */
-		expect(reader.long()).toEqual(-127 << 56);
+		/* node-int64 integer */
+		var big = reader.long();
+		expect(big.toOctetString()).toEqual('8100000000000000'); // exact
+		expect(+big).toEqual(-Infinity); // clamped
+		expect(big.valueOf()).toEqual(-Infinity);
+		expect(big.toNumber()).toEqual(-Infinity);
+		expect(big.toNumber(false)).toEqual(-Infinity);
+		expect(big.toNumber(true)).toEqual(-9151314442816848000); // rounded
 	});
 
 	it('reads 32-bit floats', function() {

--- a/nbt.js
+++ b/nbt.js
@@ -15,6 +15,7 @@
 
 	var nbt = this;
 	var zlib = require('zlib');
+	var Int64 = require('node-int64');
 
 	nbt.tagTypes = {
 		'end': 0,
@@ -56,10 +57,9 @@
 		this[nbt.tagTypes.double] = read.bind(this, 'DoubleBE', 8);
 
 		this[nbt.tagTypes.long] = function() {
-			/* FIXME: this can overflow, JS has 53 bit precision */
 			var upper = this.int();
 			var lower = this.int();
-			return (upper << 32) + lower;
+			return new Int64(upper, lower);
 		};
 
 		this[nbt.tagTypes.byteArray] = function() {

--- a/package.json
+++ b/package.json
@@ -1,26 +1,32 @@
 {
-	"name": "nbt",
-	"version": "v0.3.0",
-	"description": "A parser for NBT archives",
-	"keywords": ["nbt", "minecraft"],
-	"homepage": "https://github.com/sjmulder/nbt-js",
-	"author": "Sijmen Mulder <sjmulder@gmail.com>",
-	"main": "nbt",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/sjmulder/nbt-js.git"
-	},
-	"engines": [
-		"node >=0.10"
-	],
-	"devDependencies": {
-		"grunt": "~0.4.4",
-		"grunt-cli": "~0.1.13",
-		"grunt-jasmine-node": "~0.2.1",
-		"grunt-contrib-jshint": "~0.9.2",
-		"grunt-contrib-watch": "~0.6.0"
-	},
-	"scripts": {
-		"test": "grunt test"
-	}
+  "name": "nbt",
+  "version": "v0.3.0",
+  "description": "A parser for NBT archives",
+  "keywords": [
+    "nbt",
+    "minecraft"
+  ],
+  "homepage": "https://github.com/sjmulder/nbt-js",
+  "author": "Sijmen Mulder <sjmulder@gmail.com>",
+  "main": "nbt",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sjmulder/nbt-js.git"
+  },
+  "engines": [
+    "node >=0.10"
+  ],
+  "devDependencies": {
+    "grunt": "~0.4.4",
+    "grunt-cli": "~0.1.13",
+    "grunt-jasmine-node": "~0.2.1",
+    "grunt-contrib-jshint": "~0.9.2",
+    "grunt-contrib-watch": "~0.6.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "node-int64": "^0.3.1"
+  }
 }


### PR DESCRIPTION
Changes longs to return a [node-int64](https://github.com/broofa/node-int64); this module seems to be a good solution for 64-bit values as it supports exact, clamped, and rounded output representations. Fixes GH-1 better than the approximate solution in GH-8.

Also updated unit tests and they all pass :)
