### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"

--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
     "node >=0.10"
   ],
   "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-cli": "~0.1.13",
-    "grunt-jasmine-node": "~0.2.1",
-    "grunt-contrib-jshint": "~0.9.2",
-    "grunt-contrib-watch": "~0.6.0"
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-jasmine-node": "^0.2.1",
+    "grunt-contrib-jshint": "^0.11.0",
+    "grunt-contrib-watch": "^0.6.1"
   },
   "scripts": {
     "test": "grunt test"
   },
   "dependencies": {
-    "node-int64": "^0.3.1"
+    "node-int64": "^0.3.3"
   }
 }


### PR DESCRIPTION
Updates all dependencies, mainly for node 0.12 support, fixes this error from `npm list`:

npm ERR! invalid: readable-stream@1.0.26-2 node_modules/nbt/node_modules/grunt-contrib-jshint/node_modules/jshint/node_modules/htmlparser2/node_modules/readable-stream
npm ERR! invalid: string_decoder@0.10.25-1nbt/node_modules/grunt-contrib-jshint/node_modules/jshint/node_modules/htmlparser2/node_modules/readable-stream/node_modules/string_decoder
npm ERR! invalid: readable-stream@1.1.1
